### PR TITLE
feat: Add riscv64 architecture support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
     binary: '{{ .ProjectName }}'
     id: default
     main: ./cmd/discovery/main.go


### PR DESCRIPTION
- Added `riscv64` to the list of supported architectures in .goreleaser.yaml
- This change enables building binaries for the RISC-V architecture, expanding compatibility with more platforms.