### PR TITLE
ci(osv): own the scanner setup instead of the reusable workflow

### DIFF
--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -29,14 +29,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Cache Go modules
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Install osv-scanner
         run: |
           go install "github.com/google/osv-scanner/v2/cmd/osv-scanner@${OSV_SCANNER_VERSION}"

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -20,17 +20,17 @@ jobs:
       OSV_SCANNER_VERSION: v2.4.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go.mod
 
       - name: Cache Go modules
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload SARIF artifact
         if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: OSV Scanner SARIF file
           path: results.sarif
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload SARIF to code-scanning
         if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           sarif_file: results.sarif
 

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -1,6 +1,5 @@
 name: OSV-Scanner PR Scan
 
-# Change "main" to your default branch if you use a different name, i.e. "master"
 on:
   pull_request:
   push:
@@ -10,12 +9,65 @@ on:
     branches: [main]
 
 permissions:
-  # Require writing security events to upload SARIF file to security tab
   security-events: write
-  # Only need to read contents adn actions
   contents: read
   actions: read
 
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"
+    runs-on: ubuntu-latest
+    env:
+      OSV_SCANNER_VERSION: v2.4.0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Go modules
+        uses: actions/cache@v6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Install osv-scanner
+        run: |
+          go install "github.com/google/osv-scanner/v2/cmd/osv-scanner@${OSV_SCANNER_VERSION}"
+          osv-scanner --version
+
+      - name: Run osv-scanner
+        id: scan
+        continue-on-error: true
+        run: |
+          osv-scanner scan source \
+            --recursive \
+            --format=sarif \
+            --output=results.sarif \
+            ./
+
+      - name: Upload SARIF artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: OSV Scanner SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code-scanning
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif
+
+      - name: Fail on findings
+        if: steps.scan.outcome == 'failure'
+        run: |
+          echo "osv-scanner reported vulnerabilities; see the Security tab or the results.sarif artifact."
+          exit 1

--- a/.github/workflows/osv-scanner-pr.yaml
+++ b/.github/workflows/osv-scanner-pr.yaml
@@ -20,7 +20,7 @@ jobs:
       OSV_SCANNER_VERSION: v2.4.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -30,7 +30,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Cache Go modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -53,21 +53,25 @@ jobs:
             ./
 
       - name: Upload SARIF artifact
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: OSV Scanner SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to code-scanning
-        if: ${{ !cancelled() }}
-        uses: github/codeql-action/upload-sarif@v4
+        if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif
 
-      - name: Fail on findings
+      - name: Report scan outcome
         if: steps.scan.outcome == 'failure'
         run: |
-          echo "osv-scanner reported vulnerabilities; see the Security tab or the results.sarif artifact."
+          if [ -f results.sarif ]; then
+            echo "osv-scanner reported vulnerabilities; see the Security tab or the results.sarif artifact."
+          else
+            echo "osv-scanner failed before writing results.sarif; see the 'Run osv-scanner' step logs."
+          fi
           exit 1

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,17 +5,7 @@ reason = """
 Patched in github.com/google/go-attestation v0.6.1 per GHSA-9r4w-jg96-92mv
 (vulnerable_version_range <= 0.6.0, patched_versions v0.6.1). We are on
 v0.6.1. The OSV database entry still lists the range as introduced=0 with
-no fixed event, so osv-scanner flags it; drop this ignore once OSV records
+no fixed event and no vulnerable_functions, so neither module-version nor
+symbol-level analysis can rule it out. Drop this ignore once OSV records
 the fixed version.
-"""
-
-[[IgnoredVulns]]
-id = "GO-2026-5932"
-ignoreUntil = 2026-10-01
-reason = """
-golang.org/x/crypto/openpgp is deprecated by design (unmaintained, unsafe)
-and no upstream fix is planned. We only pull x/crypto as an indirect
-dependency and do not import any golang.org/x/crypto/openpgp subpackage
-(verified with go list -deps). Re-check when transitive deps drop the
-openpgp import paths or migrate off x/crypto.
 """


### PR DESCRIPTION
Replace google/osv-scanner-action reusable workflow with an inline job that installs osv-scanner from source using the Go toolchain from go.mod. The old reusable workflow ran the scanner inside a Docker container that bundled its own (older) Go toolchain, which crashed govulncheck when go.mod required a newer Go than the container provided, silently degrading the scan to module-version-only matching.

Owning the setup lets us:
- guarantee the scanner and the code use the same Go toolchain,
- pin the scanner version explicitly and independently of the reusable workflow's release cadence,
- run govulncheck / package-level analysis reliably.

Also drop the GO-2026-5932 (golang.org/x/crypto/openpgp) ignore: with the fixed toolchain the scanner now correctly determines that no transitive import touches any openpgp subpackage and excludes the finding on its own.