### PR TITLE
Fix challenger_server URL when it has a trailing slash

### DIFF
--- a/cmd/discovery/client/client.go
+++ b/cmd/discovery/client/client.go
@@ -120,9 +120,16 @@ func (c *Client) GetPassphrase(partition *partitions.Partition, attempts int) (s
 	return c.waitPassWithTPMAttestation(serverURL, additionalHeaders, partition, attempts)
 }
 
+// attestationEndpointURL builds the TPM attestation endpoint from a challenger
+// server URL, tolerating any number of trailing slashes on the input so that
+// both "http://host/challenge" and "http://host/challenge/" work.
+func attestationEndpointURL(serverURL string) string {
+	return fmt.Sprintf("%s/tpm-attestation", strings.TrimRight(serverURL, "/"))
+}
+
 // waitPassWithTPMAttestation implements the new TPM remote attestation flow over WebSocket
 func (c *Client) waitPassWithTPMAttestation(serverURL string, additionalHeaders map[string]string, p *partitions.Partition, attempts int) (string, error) {
-	attestationEndpoint := fmt.Sprintf("%s/tpm-attestation", serverURL)
+	attestationEndpoint := attestationEndpointURL(serverURL)
 	c.Logger.Debugf("Debug: TPM attestation endpoint: %s", attestationEndpoint)
 
 	// Step 1: Initialize Remote Attestation Client (outside the retry loop)

--- a/cmd/discovery/client/client_test.go
+++ b/cmd/discovery/client/client_test.go
@@ -1,0 +1,46 @@
+package client
+
+import "testing"
+
+func TestAttestationEndpointURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverURL string
+		want      string
+	}{
+		{
+			name:      "no trailing slash",
+			serverURL: "http://foo.example:8082/challenge",
+			want:      "http://foo.example:8082/challenge/tpm-attestation",
+		},
+		{
+			name:      "trailing slash is normalized",
+			serverURL: "http://foo.example:8082/challenge/",
+			want:      "http://foo.example:8082/challenge/tpm-attestation",
+		},
+		{
+			name:      "multiple trailing slashes are normalized",
+			serverURL: "http://foo.example:8082/challenge///",
+			want:      "http://foo.example:8082/challenge/tpm-attestation",
+		},
+		{
+			name:      "bare host without path",
+			serverURL: "http://foo.example:8082",
+			want:      "http://foo.example:8082/tpm-attestation",
+		},
+		{
+			name:      "bare host with trailing slash",
+			serverURL: "http://foo.example:8082/",
+			want:      "http://foo.example:8082/tpm-attestation",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := attestationEndpointURL(tc.serverURL)
+			if got != tc.want {
+				t.Errorf("attestationEndpointURL(%q) = %q, want %q", tc.serverURL, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, configuring `challenger_server: http://host:8082/challenge/` produced `http://host:8082/challenge//tpm-attestation` due to a plain Sprintf join, and most servers 404 that path with no useful client-side signal. Extract a small helper that trims trailing slashes before appending `/tpm-attestation`, and cover both forms plus bare-host variants with a table-driven unit test.

Fixes https://github.com/kairos-io/kairos/issues/1386