### PR TITLE
chore(deps): consume legacy unlock SDK fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/mdns v1.0.7
-	github.com/kairos-io/kairos-sdk v0.25.1
+	github.com/kairos-io/kairos-sdk v0.25.2-0.20260805143930-4d8b3f8e770b
 	github.com/kairos-io/tpm-helpers v0.0.0-20260702080541-9b3e057e2f32
 	github.com/mudler/go-pluggable v0.0.0-20230126220627-7710299a0ae5
 	github.com/mudler/go-processmanager v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,8 @@ github.com/kairos-io/kairos-sdk v0.25.0 h1:cLHOpOlSiTrWZOjy/A5CbTAp9pBxDrM9/TzhQ
 github.com/kairos-io/kairos-sdk v0.25.0/go.mod h1:lsRj0qTLq9XgEOAIOMIpGhMakUqhyTS9TVchvw2XIzw=
 github.com/kairos-io/kairos-sdk v0.25.1 h1:52Ptex/9AE26mZQruOKuyiLQieV5hzPmV1xfmnYtzR8=
 github.com/kairos-io/kairos-sdk v0.25.1/go.mod h1:ebgJNvYL9JbE4ndZYk7bFCTCdJBFMTAiQvmxm2Ia5Pw=
+github.com/kairos-io/kairos-sdk v0.25.2-0.20260805143930-4d8b3f8e770b h1:O3Abh4NU+MsKp8scfSAoAtirY/PQgmqlB4kYS7LZvoU=
+github.com/kairos-io/kairos-sdk v0.25.2-0.20260805143930-4d8b3f8e770b/go.mod h1:ebgJNvYL9JbE4ndZYk7bFCTCdJBFMTAiQvmxm2Ia5Pw=
 github.com/kairos-io/tpm-helpers v0.0.0-20260702080541-9b3e057e2f32 h1:uunggNSibnMrKkvBblxmpsa1BNGHXFqsJf0zyUm0Eas=
 github.com/kairos-io/tpm-helpers v0.0.0-20260702080541-9b3e057e2f32/go.mod h1:VCNa+JJQgXutnWNJvZyNSemeMSy2w+b9SKTkItiIkro=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=


### PR DESCRIPTION
## Summary\n\nPin kairos-sdk to the merged legacy unlabeled-partition unlock fix from kairos-sdk#822. The selected SDK commit also contains the live-media GRUB helper from kairos-sdk#823.\n\n## Testing\n\nThe updated module and checksum were resolved directly from GitHub. Targeted Go tests could not start because this environment receives HTTP 403 while fetching unrelated modules from their vanity domains. CI will perform the full verification.\n\nSigned-off-by: Ettore Di Giacinto <mudler@localai.io>